### PR TITLE
Add two buttons for easier colorbar handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ else:
     from setuptools import setup
 
     setup(name='pyncview',
-        version='0.99.29',
+        version='0.99.30',
         description='NetCDF viewer written in Python',
         url='http://github.com/BoldingBruggeman/pyncview',
         author='Jorn Bruggeman',


### PR DESCRIPTION
This commit adds two buttons to the slicing tab if the current figure
has a colorbar.  A click on the first button makes the colorbar
symmetric about zero, the second button allows to quickly switch
between recently used colormaps.

It is often useful to show positive and negative values in a colorplot
with two different colors, for example when we look at velocity.  To do
this, it has so far been necessary to click "Properties", set the
minimum and maximum value of the colorbar to be symmetric about zero and
to choose a diverging colormap.  This commit simplifies this workflow by
putting all these actions in a single button.

Since this new button changes the colormap, we might want to switch
back to the previously used colormap when we look at a different
quantity that is not symmetric about zero.  For this purpose, a menu
button is added as well, which allows to switch from the current
colormap back to a recently used colormap.  This menu also suggests
some commonly used colormaps, and is a lot faster to use than the
complete colormap-menu in the "Properties" dialog.