### PR TITLE
Fix issue with missing minus sign glyph

### DIFF
--- a/pyncview/pyncview.py
+++ b/pyncview/pyncview.py
@@ -40,6 +40,7 @@ except ImportError as e:
 import matplotlib
 #matplotlib.rcParams['backend.qt4'] = mpl_qt4_backend
 matplotlib.use('agg')
+matplotlib.rcParams.update({"axes.unicode_minus": False})
 
 # Override basemap data directory if running from binary distribution.
 if hasattr(sys,'frozen'):


### PR DESCRIPTION
This pull request fixes the following error message that appears for me in the latest version of PyNcView:
`UserWarning: Glyph 8722 (\N{MINUS SIGN}) missing from current font.`
In consequence of this "missing glyph", minus signs in the axes labels are replaced by boxes, making the numbers hard to read.

With the here-proposed fix, minus signs are replaced by the regular dash "-", which can be displayed with no problems on my computer, making the numbers readable again.

I don't know if this problem occurs for everyone (probably not), but if you have the same problem, you may use this fix. Until the fix makes it into the official PyNcView code, you can clone the repository, check out this branch and write `pip install .` in the repository folder.

Thanks to [mok0](https://stackoverflow.com/questions/58361594/matplotlib-glyph-8722-missing-from-current-font-despite-being-in-font-manager#comment134885487_64376187) for this solution.