### PR TITLE
Fix Qt WindowModal in progress dialog

### DIFF
--- a/pyncview/pyncview.py
+++ b/pyncview/pyncview.py
@@ -1372,7 +1372,7 @@ class VisualizeDialog(QtWidgets.QMainWindow):
         QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
 
         progdialog = QtWidgets.QProgressDialog('Examining data range...',None,0,100,self,QtCore.Qt.WindowType.Dialog|QtCore.Qt.WindowType.WindowTitleHint)
-        progdialog.setWindowModality(QtCore.Qt.WindowType.WindowModal)
+        progdialog.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         progdialog.setWindowTitle('Please wait')
 
         try:
@@ -1524,7 +1524,7 @@ class VisualizeDialog(QtWidgets.QMainWindow):
 
             # Create progress dialog
             dlgProgress = QtWidgets.QProgressDialog('Please wait while stills are generated.','Cancel',imin,imax,self,QtCore.Qt.WindowType.Dialog|QtCore.Qt.WindowType.WindowTitleHint)
-            dlgProgress.setWindowModality(QtCore.Qt.WindowType.WindowModal)
+            dlgProgress.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
             dlgProgress.setWindowTitle('Please wait...')
 
             try:


### PR DESCRIPTION
Hi @jornbr ,

With the update to Qt6, there seems to be an error with the progress window that appears when one tries to set the axes boundaries based on the value range of the shown variable. I believe the error is because WindowModal is part of a different enum. This is fixed with this change.

<img width="835" height="493" alt="Screenshot illustrating the problem" src="https://github.com/user-attachments/assets/33045c68-4ed5-4a2d-975c-b0060c869ef3" />

See also: https://doc.qt.io/qtforpython-6/PySide6/QtCore/Qt.html#PySide6.QtCore.Qt.WindowModality

Please take a look, try it out, and merge it if you agree with my fix.

Thanks,
Markus